### PR TITLE
Fix `validator` import, remove invalid ESx-code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
-const isUrl = require('validator/lib/isUrl');
+const { isUrl }  = require('validator');
 
 module.exports = {
   improve: 'apostrophe-schemas',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-anchor-field-type",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Adds an `anchor` field type to apostrophe-schemas that populates a select with ID and name attributes from a target URL",
   "main": "index.js",
   "directories": {

--- a/public/js/anchorField.js
+++ b/public/js/anchorField.js
@@ -43,9 +43,7 @@ apos.define('apostrophe-schemas', {
             } else {
               // longform options
               if (item.fieldName) {
-                remotes[item.fieldName] = {
-                  ...item
-                };
+                remotes[item.fieldName] = item;
               } else {
                 console.error('If using explicit configuration, expects fieldName property');
                 console.error('See https://github.com/apostrophecms/apostrophe-anchor-field-type');
@@ -72,7 +70,7 @@ apos.define('apostrophe-schemas', {
         }
 
         function getInitialChoices() {
-          setTimeout(() => {
+          setTimeout(function() {
             getChoices();
           }, 500);
         }
@@ -99,10 +97,8 @@ apos.define('apostrophe-schemas', {
             return populateChoices([])
           }
 
-          options = {
-            key: key,
-            ...current
-          };
+          options = current;
+          options[key] = key;
 
           delete options.$observable;
 


### PR DESCRIPTION
 - As per [the doc](https://www.npmjs.com/package/validator), the import pattern `validator/lib/isUrl` only works in ES6 contexts. In order to work in "plain JS" contexts, it needs to be included as a plain old object. 
 - Removed spread operators, arrow functions, and such, from `public/js` files, as they cause error during the build process (uglify-js can only process vanilla code)