### PR TITLE
Fix crash during anchor retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
           if (type === 'join') {
             var criteria = { _id: key };
             var doc = await self.apos.pages.find(req, criteria, { _url: 1 }).toObject();
-            page = await axios.get(req.baseUrlWithPrefix + doc._url);
+            page = await axios.get(doc._url);
           } else {
             // if invalid url, bail
             if (!isUrl(key)) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ module.exports = {
           if (type === 'join') {
             var criteria = { _id: key };
             var doc = await self.apos.pages.find(req, criteria, { _url: 1 }).toObject();
-            page = await axios.get(doc._url);
+
+            let targetURL = isURL(doc._url, { allow_protocol_relative_urls: true }) ? doc._url : req.baseUrlWithPrefix + doc._url
+            page = await axios.get(targetURL);
           } else {
             // if invalid url, bail
             if (!isUrl(key)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-anchor-field-type",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Adds an `anchor` field type to apostrophe-schemas that populates a select with ID and name attributes from a target URL",
   "main": "index.js",
   "directories": {

--- a/public/js/anchorField.js
+++ b/public/js/anchorField.js
@@ -80,6 +80,9 @@ apos.define('apostrophe-schemas', {
           var key;
           var options;
 
+          console.log('getChoices - 0', remotes);
+          console.log('getChoices - 1', remotes['_page']);
+          console.log('getChoices - 2', remotes['_page'].$observable);
           for (var remoteName in remotes) {
             if (remotes[remoteName].$observable.is(':visible')) {
               current = remotes[remoteName]
@@ -97,8 +100,8 @@ apos.define('apostrophe-schemas', {
             return populateChoices([])
           }
 
-          options = current;
-          options[key] = key;
+          options = _.clone(current);
+          options.key = key;
 
           delete options.$observable;
 
@@ -139,7 +142,7 @@ apos.define('apostrophe-schemas', {
         return setImmediate(callback);
       },
       convert: function (data, name, $field, $el, field, callback) {
-        data[name] = $field.val();        
+        data[name] = $field.val();
         if (field.required && (!(data[name] && data[name].length))) {
           return setImmediate(_.partial(callback, 'required'));
         }

--- a/public/js/anchorField.js
+++ b/public/js/anchorField.js
@@ -80,9 +80,6 @@ apos.define('apostrophe-schemas', {
           var key;
           var options;
 
-          console.log('getChoices - 0', remotes);
-          console.log('getChoices - 1', remotes['_page']);
-          console.log('getChoices - 2', remotes['_page'].$observable);
           for (var remoteName in remotes) {
             if (remotes[remoteName].$observable.is(':visible')) {
               current = remotes[remoteName]
@@ -90,7 +87,7 @@ apos.define('apostrophe-schemas', {
           }
 
           if (current.fieldType === 'join') {
-            key = current.$observable.find('[data-chooser-choice]:first').attr('data-chooser-choice');  
+            key = current.$observable.find('[data-chooser-choice]:first').attr('data-chooser-choice');
           } else {
             key = current.$observable.val();
           }
@@ -132,7 +129,7 @@ apos.define('apostrophe-schemas', {
 
         function populateValue() {
           if (newChoices) {
-            value = ((data[name] === undefined) && newChoices[0]) ? newChoices[0].value : data[name];  
+            value = ((data[name] === undefined) && newChoices[0]) ? newChoices[0].value : data[name];
           } else {
             value = 'Nothing set';
           }


### PR DESCRIPTION
TODO

# Motivation 

Integrating `apostrophe-anchor-field-type` to an Apostrophe projects did not work for us. When a schema contains an `apostrophe-anchor` type, the anchor field does appear, but the choices don't populate, and this error gets thrown : 

````
Uncaught TypeError: Cannot read property 'fieldType' of undefined
````

# Solutions

 - Problem was that the `$observable` field was `delete`ed to avoid a circular JSON strucutre as the `options` object is passed to the API call, making every subsequent request fail. Problem solved by `_.clone`ing the structure, and deleting the field from the clone, leaving the global reference untampered.
 - The URL constructed by the backend script uses the concatenation of `req.baseUrlWithPrefix` and `doc._url`, which in our case was yielding : `//localhost:8080http://en-au.localhost:8080/slug-of-the-page`. Added a check to see if the `doc._url` is a valid URL, if so, use it, otherwise, fallback to the concatenation. 