### PR TITLE
Updates version for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Spells out what is assumed in shorthand syntax.
 
 ## Changelog
 
-### Unreleased
+### 1.0.3 (2021-04-07)
 
 - Updates axios version due to security patch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-anchor-field-type",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "Adds an `anchor` field type to apostrophe-schemas that populates a select with ID and name attributes from a target URL",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
1.0.3 was never published. I think I updated to 1.0.4 without checking. https://www.npmjs.com/package/apostrophe-anchor-field-type